### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/856/327/47/85632747.geojson
+++ b/data/856/327/47/85632747.geojson
@@ -893,6 +893,11 @@
     },
     "wof:country":"NR",
     "wof:country_alpha3":"NRU",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6",
+        "quattroshapes"
+    ],
     "wof:geomhash":"8eec6e6ba1c6a4f62275889cdf88096f",
     "wof:hierarchy":[
         {
@@ -909,7 +914,7 @@
         "eng",
         "nau"
     ],
-    "wof:lastmodified":1566672066,
+    "wof:lastmodified":1582315519,
     "wof:name":"Nauru",
     "wof:parent_id":102191583,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.