### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/856/327/47/85632747.geojson
+++ b/data/856/327/47/85632747.geojson
@@ -28,6 +28,9 @@
     "mz:is_current":1,
     "mz:max_zoom":10.0,
     "mz:min_zoom":5.0,
+    "name:abk_x_preferred":[
+        "\u041d\u0430\u0443\u0440\u0443"
+    ],
     "name:ace_x_preferred":[
         "Nauru"
     ],
@@ -40,6 +43,9 @@
     "name:aka_x_preferred":[
         "Naworu"
     ],
+    "name:aka_x_variant":[
+        "Nauru"
+    ],
     "name:als_x_preferred":[
         "Nauru"
     ],
@@ -48,6 +54,15 @@
     ],
     "name:amh_x_variant":[
         "\u1293\u12a1\u1229"
+    ],
+    "name:ami_x_preferred":[
+        "Nauru"
+    ],
+    "name:ang_x_preferred":[
+        "Nauru"
+    ],
+    "name:anp_x_preferred":[
+        "\u0928\u0948\u0930\u0942"
     ],
     "name:ara_x_preferred":[
         "\u0646\u0627\u0648\u0631\u0648"
@@ -58,11 +73,20 @@
     "name:arg_x_preferred":[
         "Nauru"
     ],
+    "name:ary_x_preferred":[
+        "\u0646\u0627\u0648\u0631\u0648"
+    ],
     "name:arz_x_preferred":[
         "\u0646\u0627\u0648\u0631\u0648"
     ],
+    "name:asm_x_preferred":[
+        "\u09a8\u09be\u0989\u09f0\u09c1"
+    ],
     "name:ast_x_preferred":[
         "Nauru"
+    ],
+    "name:avk_x_preferred":[
+        "Naurua"
     ],
     "name:azb_x_preferred":[
         "\u0646\u0627\u0626\u0648\u0631\u0648"
@@ -75,6 +99,9 @@
     ],
     "name:bam_x_preferred":[
         "Nawuru"
+    ],
+    "name:ban_x_preferred":[
+        "Nauru"
     ],
     "name:bar_x_preferred":[
         "Nauru"
@@ -132,6 +159,9 @@
     ],
     "name:che_x_preferred":[
         "\u041d\u0430\u0443\u0440\u0443"
+    ],
+    "name:chr_x_preferred":[
+        "\u13c3\u13a4\u13b7"
     ],
     "name:chu_x_preferred":[
         "\u041d\u0430\u043e\u0443\u0440\u043e\u0443"
@@ -241,6 +271,9 @@
     "name:gag_x_preferred":[
         "Nauru"
     ],
+    "name:gcr_x_preferred":[
+        "Nauru"
+    ],
     "name:ger_x_variant":[
         "Republik Nauru"
     ],
@@ -263,6 +296,9 @@
         "\u0928\u094c\u0930\u0941"
     ],
     "name:gor_x_preferred":[
+        "Nauru"
+    ],
+    "name:gpe_x_preferred":[
         "Nauru"
     ],
     "name:grn_x_preferred":[
@@ -412,6 +448,9 @@
     "name:lit_x_variant":[
         "Nauru Respublika"
     ],
+    "name:lld_x_preferred":[
+        "Nauru"
+    ],
     "name:lmo_x_preferred":[
         "Nauru"
     ],
@@ -439,6 +478,12 @@
     "name:mar_x_variant":[
         "\u0928\u090a\u0930\u0941"
     ],
+    "name:mhr_x_preferred":[
+        "\u041d\u0430\u0443\u0440\u0443"
+    ],
+    "name:min_x_preferred":[
+        "Nauru"
+    ],
     "name:mkd_x_preferred":[
         "\u041d\u0430\u0443\u0440\u0443"
     ],
@@ -453,6 +498,9 @@
     ],
     "name:mlt_x_variant":[
         "Nauru"
+    ],
+    "name:mni_x_preferred":[
+        "\uabc5\uabe5\uabce\uabd4\uabe8"
     ],
     "name:mon_x_preferred":[
         "\u041d\u0430\u0443\u0440\u0443"
@@ -586,6 +634,9 @@
     "name:sgs_x_preferred":[
         "Nauru"
     ],
+    "name:shn_x_preferred":[
+        "\u1019\u102d\u1030\u1004\u103a\u1038\u107c\u1062\u101d\u103a\u101b\u1030\u1038"
+    ],
     "name:sin_x_preferred":[
         "\u0db1\u0dcf\u0dc0\u0dd4\u0dbb\u0dd4"
     ],
@@ -601,11 +652,20 @@
     "name:sme_x_preferred":[
         "Nauru"
     ],
+    "name:smn_x_preferred":[
+        "Nauru"
+    ],
     "name:smo_x_preferred":[
+        "Nauru"
+    ],
+    "name:sms_x_preferred":[
         "Nauru"
     ],
     "name:sna_x_preferred":[
         "Nauru"
+    ],
+    "name:snd_x_preferred":[
+        "\u0646\u0627\u0626\u0648\u0631\u0648"
     ],
     "name:som_x_preferred":[
         "Nawru"
@@ -640,6 +700,9 @@
     "name:szl_x_preferred":[
         "Nauru"
     ],
+    "name:szy_x_preferred":[
+        "Nauru"
+    ],
     "name:tah_x_preferred":[
         "Nauru"
     ],
@@ -651,6 +714,9 @@
     ],
     "name:tat_x_preferred":[
         "\u041d\u0430\u0443\u0440\u0443"
+    ],
+    "name:tay_x_preferred":[
+        "Nauru"
     ],
     "name:tel_x_preferred":[
         "\u0c28\u0c4c\u0c30\u0c41"
@@ -680,6 +746,9 @@
     "name:tpi_x_preferred":[
         "Nauru"
     ],
+    "name:trv_x_preferred":[
+        "Nworu"
+    ],
     "name:tuk_x_preferred":[
         "Nauru"
     ],
@@ -691,6 +760,9 @@
     ],
     "name:twi_x_preferred":[
         "Nauru"
+    ],
+    "name:udm_x_preferred":[
+        "\u041d\u0430\u0443\u0440\u0443"
     ],
     "name:uig_x_preferred":[
         "\u0646\u0627\u06cb\u0631\u06c7"
@@ -709,6 +781,9 @@
         "\u0646\u0624\u0631\u0648"
     ],
     "name:uzb_x_preferred":[
+        "Nauru"
+    ],
+    "name:vec_x_preferred":[
         "Nauru"
     ],
     "name:vep_x_preferred":[
@@ -738,6 +813,9 @@
     "name:xmf_x_preferred":[
         "\u10dc\u10d0\u10e3\u10e0\u10e3"
     ],
+    "name:yid_x_preferred":[
+        "\u05e0\u05d0\u05d5\u05e8\u05d5"
+    ],
     "name:yor_x_preferred":[
         "N\u00e0\u00far\u00f9"
     ],
@@ -746,6 +824,9 @@
     ],
     "name:yue_x_preferred":[
         "\u7459\u9b6f"
+    ],
+    "name:zea_x_preferred":[
+        "Nauru"
     ],
     "name:zha_x_preferred":[
         "Nauru"
@@ -989,7 +1070,7 @@
         "eng",
         "nau"
     ],
-    "wof:lastmodified":1636494974,
+    "wof:lastmodified":1690849757,
     "wof:name":"Nauru",
     "wof:parent_id":102191583,
     "wof:placetype":"country",

--- a/data/856/756/07/85675607.geojson
+++ b/data/856/756/07/85675607.geojson
@@ -59,6 +59,9 @@
     "name:epo_x_preferred":[
         "Buada"
     ],
+    "name:est_x_preferred":[
+        "Buada ringkond"
+    ],
     "name:fas_x_preferred":[
         "\u0628\u062e\u0634 \u0628\u0648\u0627\u062f\u0627"
     ],
@@ -116,6 +119,9 @@
     "name:kor_x_preferred":[
         "\ubd80\uc544\ub2e4 \uad6c"
     ],
+    "name:kor_x_variant":[
+        "\ubd80\uc544\ub2e4\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Buadas distrikts"
     ],
@@ -158,6 +164,9 @@
     "name:rus_x_preferred":[
         "\u0411\u0443\u0430\u0434\u0430"
     ],
+    "name:sgs_x_preferred":[
+        "Buadas apskr\u0117t\u0117s"
+    ],
     "name:sin_x_preferred":[
         "\u0db6\u0dd4\u0d85\u0da9\u0dcf \u0daf\u0dd2\u0dc3\u0dca\u0dad\u0dca\u0dbb\u0dd2\u0d9a\u0dca\u0d9a\u0dba"
     ],
@@ -196,6 +205,9 @@
     ],
     "name:zho_x_preferred":[
         "\u90e8\u4e9e\u9054\u5340"
+    ],
+    "name:zho_x_variant":[
+        "\u5e03\u963f\u8fbe\u533a"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"NRU",
@@ -316,7 +328,7 @@
         "eng",
         "nau"
     ],
-    "wof:lastmodified":1636494973,
+    "wof:lastmodified":1690849754,
     "wof:name":"Buada",
     "wof:parent_id":85632747,
     "wof:placetype":"region",

--- a/data/856/756/25/85675625.geojson
+++ b/data/856/756/25/85675625.geojson
@@ -48,6 +48,9 @@
     "name:deu_x_preferred":[
         "Boe"
     ],
+    "name:deu_x_variant":[
+        "Distrikt Boe"
+    ],
     "name:ell_x_preferred":[
         "\u039c\u03c0\u03cc\u03b5"
     ],
@@ -60,10 +63,19 @@
     "name:epo_x_preferred":[
         "Boe"
     ],
+    "name:est_x_preferred":[
+        "Boe ringkond"
+    ],
+    "name:fas_x_preferred":[
+        "\u0628\u062e\u0634 \u0628\u0648\u0626\u0647"
+    ],
     "name:fin_x_preferred":[
         "Boe"
     ],
     "name:fra_x_preferred":[
+        "Boe"
+    ],
+    "name:frr_x_preferred":[
         "Boe"
     ],
     "name:glv_x_preferred":[
@@ -108,6 +120,9 @@
     "name:kor_x_preferred":[
         "\ubcf4\uc5d0 \uad6c"
     ],
+    "name:kor_x_variant":[
+        "\ubcf4\uc5d0\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Boe distrikts"
     ],
@@ -150,6 +165,9 @@
     "name:rus_x_preferred":[
         "\u0411\u043e\u044d"
     ],
+    "name:sgs_x_preferred":[
+        "Buoj\u0117"
+    ],
     "name:sin_x_preferred":[
         "\u0db6\u0ddc\u0dba\u0dd2 \u0daf\u0dd2\u0dc3\u0dca\u0dad\u0dca\u200d\u0dbb\u0dd2\u0d9a\u0dca\u0d9a\u0dba"
     ],
@@ -163,6 +181,9 @@
         "\u0411\u043e\u0435"
     ],
     "name:swe_x_preferred":[
+        "Boe"
+    ],
+    "name:szl_x_preferred":[
         "Boe"
     ],
     "name:tam_x_preferred":[
@@ -188,6 +209,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6cca\u5340"
+    ],
+    "name:zho_x_variant":[
+        "\u535a\u57c3\u533a"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"NRU",
@@ -308,7 +332,7 @@
         "eng",
         "nau"
     ],
-    "wof:lastmodified":1636494974,
+    "wof:lastmodified":1690849756,
     "wof:name":"Boe",
     "wof:parent_id":85632747,
     "wof:placetype":"region",

--- a/data/856/756/29/85675629.geojson
+++ b/data/856/756/29/85675629.geojson
@@ -33,6 +33,9 @@
     "name:ara_x_preferred":[
         "\u0636\u0627\u062d\u064a\u0629 \u0625\u064a\u0648"
     ],
+    "name:bel_x_preferred":[
+        "\u0410\u043a\u0440\u0443\u0433\u0430 \u0410\u0439\u0432\u0430"
+    ],
     "name:ben_x_preferred":[
         "\u0986\u09af\u09bc\u09cb \u099c\u09c7\u09b2\u09be"
     ],
@@ -63,10 +66,16 @@
     "name:est_x_preferred":[
         "Aiwo ringkond"
     ],
+    "name:fas_x_preferred":[
+        "\u0628\u062e\u0634 \u0622\u06cc\u0648\u0648"
+    ],
     "name:fin_x_preferred":[
         "Aiwo"
     ],
     "name:fra_x_preferred":[
+        "Aiwo"
+    ],
+    "name:frr_x_preferred":[
         "Aiwo"
     ],
     "name:glg_x_preferred":[
@@ -89,6 +98,9 @@
     ],
     "name:hun_x_preferred":[
         "Aiwo"
+    ],
+    "name:hye_x_preferred":[
+        "\u0531\u0575\u057e\u0578"
     ],
     "name:ind_x_preferred":[
         "Aiwo"
@@ -113,6 +125,9 @@
     ],
     "name:kor_x_preferred":[
         "\uc544\uc774\uc6cc \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\uc544\uc774\uc6cc\uad6c"
     ],
     "name:lat_x_preferred":[
         "Aivum"
@@ -162,6 +177,9 @@
     "name:rus_x_preferred":[
         "\u0410\u0439\u0432\u043e"
     ],
+    "name:sgs_x_preferred":[
+        "Aivos"
+    ],
     "name:sin_x_preferred":[
         "\u0d85\u0dba\u0dd2\u0dc0\u0ddd \u0daf\u0dd2\u0dc3\u0dca\u0dad\u0dca\u200d\u0dbb\u0dd2\u0d9a\u0dca\u0d9a\u0dba"
     ],
@@ -200,6 +218,9 @@
     ],
     "name:zho_x_preferred":[
         "\u611b\u548c\u5340"
+    ],
+    "name:zho_x_variant":[
+        "\u827e\u6c83\u533a"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"NRU",
@@ -320,7 +341,7 @@
         "eng",
         "nau"
     ],
-    "wof:lastmodified":1636494973,
+    "wof:lastmodified":1690849754,
     "wof:name":"Aiwo",
     "wof:parent_id":85632747,
     "wof:placetype":"region",

--- a/data/856/756/33/85675633.geojson
+++ b/data/856/756/33/85675633.geojson
@@ -33,6 +33,9 @@
     "name:ara_x_preferred":[
         "\u0636\u0627\u062d\u064a\u0629 \u062f\u064a\u0646\u064a\u063a\u0648\u0645\u0648\u062f\u0648"
     ],
+    "name:bel_x_preferred":[
+        "\u0414\u044d\u043d\u0456\u0433\u0430\u043c\u043e\u0434\u0443"
+    ],
     "name:ben_x_preferred":[
         "\u09a1\u09c7\u09a8\u09bf\u0997\u09cb\u09ae\u09c1\u09a6\u09cb \u099c\u09c7\u09b2\u09be"
     ],
@@ -60,10 +63,19 @@
     "name:epo_x_preferred":[
         "Denigomodu"
     ],
+    "name:est_x_preferred":[
+        "Denigomodu ringkond"
+    ],
+    "name:fas_x_preferred":[
+        "\u0628\u062e\u0634 \u062f\u0646\u06cc\u06af\u0648\u0645\u0648\u062f\u0648"
+    ],
     "name:fin_x_preferred":[
         "Denigomodu"
     ],
     "name:fra_x_preferred":[
+        "Denigomodu"
+    ],
+    "name:frr_x_preferred":[
         "Denigomodu"
     ],
     "name:glv_x_preferred":[
@@ -114,6 +126,9 @@
     "name:kor_x_preferred":[
         "\ub370\ub2c8\uace0\ubaa8\ub450 \uad6c"
     ],
+    "name:kor_x_variant":[
+        "\ub370\ub2c8\uace0\ubaa8\ub450\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Denigomodu distrikts"
     ],
@@ -153,11 +168,17 @@
     "name:por_x_preferred":[
         "Denigomodu"
     ],
+    "name:pus_x_preferred":[
+        "\u062f\u0646\u06cc\u06ab\u0648\u0645\u0648\u062f\u0648"
+    ],
     "name:ron_x_preferred":[
         "Denigomodu"
     ],
     "name:rus_x_preferred":[
         "\u0414\u0435\u043d\u0438\u0433\u043e\u043c\u043e\u0434\u0443"
+    ],
+    "name:sgs_x_preferred":[
+        "Den\u0117gamod\u016b"
     ],
     "name:sin_x_preferred":[
         "\u0da9\u0dd9\u0db1\u0dd2\u0d9c\u0ddd\u0db8\u0ddc\u0da9\u0dd4 \u0daf\u0dd2\u0dc3\u0dca\u0dad\u0dca\u200d\u0dbb\u0dd2\u0d9a\u0dca\u0d9a\u0dba"
@@ -172,6 +193,9 @@
         "\u0414\u0435\u043d\u0438\u0433\u043e\u043c\u043e\u0434\u0443"
     ],
     "name:swe_x_preferred":[
+        "Denigomodu"
+    ],
+    "name:szl_x_preferred":[
         "Denigomodu"
     ],
     "name:tam_x_preferred":[
@@ -200,6 +224,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5fb7\u5c3c\u9ad8\u83ab\u90fd\u5340"
+    ],
+    "name:zho_x_variant":[
+        "\u4ee3\u5c3c\u6208\u83ab\u675c\u533a"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"NRU",
@@ -320,7 +347,7 @@
         "eng",
         "nau"
     ],
-    "wof:lastmodified":1636494973,
+    "wof:lastmodified":1690849753,
     "wof:name":"Denigomodu",
     "wof:parent_id":85632747,
     "wof:placetype":"region",

--- a/data/856/756/37/85675637.geojson
+++ b/data/856/756/37/85675637.geojson
@@ -60,10 +60,19 @@
     "name:epo_x_preferred":[
         "Nibok"
     ],
+    "name:est_x_preferred":[
+        "Niboki ringkond"
+    ],
+    "name:fas_x_preferred":[
+        "\u0628\u062e\u0634 \u0646\u06cc\u0628\u0648\u06a9"
+    ],
     "name:fin_x_preferred":[
         "Nibok"
     ],
     "name:fra_x_preferred":[
+        "Nibok"
+    ],
+    "name:frr_x_preferred":[
         "Nibok"
     ],
     "name:glv_x_preferred":[
@@ -111,6 +120,9 @@
     "name:kor_x_preferred":[
         "\ub2c8\ubcf4\ud06c \uad6c"
     ],
+    "name:kor_x_variant":[
+        "\ub2c8\ubcf4\ud06c\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Nibokas distrikts"
     ],
@@ -153,6 +165,9 @@
     "name:rus_x_preferred":[
         "\u041d\u0438\u0431\u043e\u043a"
     ],
+    "name:sgs_x_preferred":[
+        "N\u0117boks"
+    ],
     "name:sin_x_preferred":[
         "\u0db1\u0dd2\u0db6\u0ddc\u0d9a\u0dca \u0daf\u0dd2\u0dc3\u0dca\u0dad\u0dca\u200d\u0dbb\u0dd2\u0d9a\u0dca\u0d9a\u0dba"
     ],
@@ -188,6 +203,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5c3c\u67cf\u5340"
+    ],
+    "name:zho_x_variant":[
+        "\u5c3c\u535a\u514b\u533a"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"NRU",
@@ -308,7 +326,7 @@
         "eng",
         "nau"
     ],
-    "wof:lastmodified":1636494973,
+    "wof:lastmodified":1690849755,
     "wof:name":"Nibok",
     "wof:parent_id":85632747,
     "wof:placetype":"region",

--- a/data/856/756/41/85675641.geojson
+++ b/data/856/756/41/85675641.geojson
@@ -60,6 +60,12 @@
     "name:epo_x_preferred":[
         "Uaboe"
     ],
+    "name:est_x_preferred":[
+        "Uaboe ringkond"
+    ],
+    "name:fas_x_preferred":[
+        "\u0646\u0627\u062d\u06cc\u0647 \u0627\u0648\u0627\u0628\u0648"
+    ],
     "name:fin_x_preferred":[
         "Uaboe"
     ],
@@ -110,6 +116,9 @@
     ],
     "name:kor_x_preferred":[
         "\uc6b0\uc544\ubcf4\uc5d0 \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\uc6b0\uc544\ubcf4\uc5d0\uad6c"
     ],
     "name:lav_x_preferred":[
         "Uaboe distrikts"
@@ -188,6 +197,9 @@
     ],
     "name:zho_x_preferred":[
         "\u512a\u96c5\u5e03\u5340"
+    ],
+    "name:zho_x_variant":[
+        "\u74e6\u535a\u57c3\u533a"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"NRU",
@@ -309,7 +321,7 @@
         "eng",
         "nau"
     ],
-    "wof:lastmodified":1636494974,
+    "wof:lastmodified":1690849755,
     "wof:name":"Uaboe",
     "wof:parent_id":85632747,
     "wof:placetype":"region",

--- a/data/856/756/45/85675645.geojson
+++ b/data/856/756/45/85675645.geojson
@@ -59,11 +59,20 @@
     "name:epo_x_preferred":[
         "Baiti"
     ],
+    "name:est_x_preferred":[
+        "Baiti ringkond"
+    ],
+    "name:fas_x_preferred":[
+        "\u0628\u062e\u0634 \u0628\u0627\u06cc\u062a\u0633\u06cc"
+    ],
     "name:fin_x_preferred":[
         "Baiti"
     ],
     "name:fra_x_preferred":[
         "Baiti"
+    ],
+    "name:frr_x_preferred":[
+        "Baitsi"
     ],
     "name:glv_x_preferred":[
         "Baiti"
@@ -106,6 +115,9 @@
     ],
     "name:kor_x_preferred":[
         "\ubc14\uc774\ud2f0 \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\ubc14\uc774\ud2f0\uad6c"
     ],
     "name:lav_x_preferred":[
         "Baiti distrikts"
@@ -187,6 +199,9 @@
     ],
     "name:zho_x_preferred":[
         "\u767d\u5e1d\u5340"
+    ],
+    "name:zho_x_variant":[
+        "\u62dc\u9f50\u533a"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"NRU",
@@ -307,7 +322,7 @@
         "eng",
         "nau"
     ],
-    "wof:lastmodified":1636494973,
+    "wof:lastmodified":1690849754,
     "wof:name":"Baiti",
     "wof:parent_id":85632747,
     "wof:placetype":"region",

--- a/data/856/756/49/85675649.geojson
+++ b/data/856/756/49/85675649.geojson
@@ -56,10 +56,19 @@
     "name:epo_x_preferred":[
         "Ewa"
     ],
+    "name:est_x_preferred":[
+        "Ewa ringkond"
+    ],
+    "name:fas_x_preferred":[
+        "\u0628\u062e\u0634 \u0627\u0648\u0627"
+    ],
     "name:fin_x_preferred":[
         "Ewa"
     ],
     "name:fra_x_preferred":[
+        "Ewa"
+    ],
+    "name:frr_x_preferred":[
         "Ewa"
     ],
     "name:glv_x_preferred":[
@@ -103,6 +112,9 @@
     ],
     "name:kor_x_preferred":[
         "\uc5d0\uc640 \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\uc5d0\uc640\uad6c"
     ],
     "name:lat_x_preferred":[
         "Eva"
@@ -151,6 +163,9 @@
     ],
     "name:rus_x_preferred":[
         "\u0415\u0432\u0430"
+    ],
+    "name:sgs_x_preferred":[
+        "Eva"
     ],
     "name:sin_x_preferred":[
         "\u0d92\u0dc0\u0dcf \u0daf\u0dd2\u0dc3\u0dca\u0dad\u0dca\u200d\u0dbb\u0dd2\u0d9a\u0dca\u0d9a\u0dba"
@@ -307,7 +322,7 @@
         "eng",
         "nau"
     ],
-    "wof:lastmodified":1636494974,
+    "wof:lastmodified":1690849756,
     "wof:name":"Ewa",
     "wof:parent_id":85632747,
     "wof:placetype":"region",

--- a/data/856/756/55/85675655.geojson
+++ b/data/856/756/55/85675655.geojson
@@ -59,10 +59,19 @@
     "name:epo_x_preferred":[
         "Anetan"
     ],
+    "name:est_x_preferred":[
+        "Anetani ringkond"
+    ],
+    "name:fas_x_preferred":[
+        "\u0628\u062e\u0634 \u0622\u0646\u062a\u0627\u0646"
+    ],
     "name:fin_x_preferred":[
         "Anetan"
     ],
     "name:fra_x_preferred":[
+        "Anetan"
+    ],
+    "name:frr_x_preferred":[
         "Anetan"
     ],
     "name:glv_x_preferred":[
@@ -107,6 +116,9 @@
     "name:kor_x_preferred":[
         "\uc544\ub124\ud0c4 \uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc544\ub124\ud0c4\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Anetanas distrikts"
     ],
@@ -149,6 +161,9 @@
     "name:rus_x_preferred":[
         "\u0410\u043d\u0435\u0442\u0430\u043d"
     ],
+    "name:sgs_x_preferred":[
+        "Anetans"
+    ],
     "name:sin_x_preferred":[
         "\u0d87\u0db1\u0dd9\u0da7\u0db1\u0dca \u0daf\u0dd2\u0dc3\u0dca\u0dad\u0dca\u200d\u0dbb\u0dd2\u0d9a\u0dca\u0d9a\u0dba"
     ],
@@ -184,6 +199,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5b89\u9102\u7058\u5340"
+    ],
+    "name:zho_x_variant":[
+        "\u963f\u5185\u5766\u533a"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"NRU",
@@ -304,7 +322,7 @@
         "eng",
         "nau"
     ],
-    "wof:lastmodified":1636494973,
+    "wof:lastmodified":1690849755,
     "wof:name":"Anetan",
     "wof:parent_id":85632747,
     "wof:placetype":"region",

--- a/data/856/756/59/85675659.geojson
+++ b/data/856/756/59/85675659.geojson
@@ -32,6 +32,9 @@
     "name:ara_x_preferred":[
         "\u0636\u0627\u062d\u064a\u0629 \u0623\u0646\u0627\u0628\u0627\u0631"
     ],
+    "name:bel_x_preferred":[
+        "\u0410\u043d\u0430\u0431\u0430\u0440"
+    ],
     "name:ben_x_preferred":[
         "\u0986\u09a8\u09be\u09ac\u09be\u09b0 \u099c\u09c7\u09b2\u09be"
     ],
@@ -109,6 +112,9 @@
     ],
     "name:kor_x_preferred":[
         "\uc544\ub098\ubc14\ub974 \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\uc544\ub098\ubc14\ub974\uad6c"
     ],
     "name:lav_x_preferred":[
         "Anabaras distrikts"
@@ -319,7 +325,7 @@
         "eng",
         "nau"
     ],
-    "wof:lastmodified":1636494972,
+    "wof:lastmodified":1690849753,
     "wof:name":"Anabar",
     "wof:parent_id":85632747,
     "wof:placetype":"region",

--- a/data/856/756/63/85675663.geojson
+++ b/data/856/756/63/85675663.geojson
@@ -59,10 +59,19 @@
     "name:epo_x_preferred":[
         "Ijuw"
     ],
+    "name:est_x_preferred":[
+        "Ijuwi ringkond"
+    ],
+    "name:fas_x_preferred":[
+        "\u0646\u0627\u062d\u06cc\u0647 \u0627\u06cc\u062c\u0648\u0648"
+    ],
     "name:fin_x_preferred":[
         "Ijuw"
     ],
     "name:fra_x_preferred":[
+        "Ijuw"
+    ],
+    "name:frr_x_preferred":[
         "Ijuw"
     ],
     "name:glv_x_preferred":[
@@ -106,6 +115,9 @@
     ],
     "name:kor_x_preferred":[
         "\uc774\uc720\ube0c \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\uc774\uc720\ube0c\uad6c"
     ],
     "name:lav_x_preferred":[
         "Iju distrikts"
@@ -307,7 +319,7 @@
         "eng",
         "nau"
     ],
-    "wof:lastmodified":1636494974,
+    "wof:lastmodified":1690849755,
     "wof:name":"Ijuw",
     "wof:parent_id":85632747,
     "wof:placetype":"region",

--- a/data/856/756/67/85675667.geojson
+++ b/data/856/756/67/85675667.geojson
@@ -59,6 +59,9 @@
     "name:epo_x_preferred":[
         "Anibare"
     ],
+    "name:est_x_preferred":[
+        "Anibare ringkond"
+    ],
     "name:fas_x_preferred":[
         "\u0628\u062e\u0634 \u0627\u0646\u06cc\u0628\u06cc\u0631"
     ],
@@ -113,6 +116,9 @@
     "name:kor_x_preferred":[
         "\uc544\ub2c8\ubc14\ub808 \uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc544\ub2c8\ubc14\ub808\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Anabares distrikts"
     ],
@@ -155,6 +161,9 @@
     "name:rus_x_preferred":[
         "\u0410\u043d\u0438\u0431\u0430\u0440"
     ],
+    "name:sgs_x_preferred":[
+        "An\u012bbars"
+    ],
     "name:sin_x_preferred":[
         "\u0d85\u0db1\u0dd2\u0db6\u0dbb\u0dda \u0daf\u0dd2\u0dc3\u0dca\u0dad\u0dca\u200d\u0dbb\u0dd2\u0d9a\u0dca\u0d9a\u0dba"
     ],
@@ -190,6 +199,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5b89\u5c3c\u5df4\u60f9\u5340"
+    ],
+    "name:zho_x_variant":[
+        "\u963f\u5c3c\u5df4\u96f7\u533a"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"NRU",
@@ -310,7 +322,7 @@
         "eng",
         "nau"
     ],
-    "wof:lastmodified":1636494972,
+    "wof:lastmodified":1690849753,
     "wof:name":"Anibare",
     "wof:parent_id":85632747,
     "wof:placetype":"region",

--- a/data/856/756/69/85675669.geojson
+++ b/data/856/756/69/85675669.geojson
@@ -32,6 +32,9 @@
     "name:ara_x_preferred":[
         "\u0636\u0627\u062d\u064a\u0629 \u0645\u064a\u0646\u064a\u0646\u063a"
     ],
+    "name:bel_x_preferred":[
+        "\u041c\u0435\u043d\u0435\u043d\u0433"
+    ],
     "name:ben_x_preferred":[
         "\u09ae\u09c7\u09a8\u09c7\u0982 \u099c\u09c7\u09b2\u09be"
     ],
@@ -59,10 +62,19 @@
     "name:epo_x_preferred":[
         "Meneng"
     ],
+    "name:est_x_preferred":[
+        "Menengi ringkond"
+    ],
+    "name:fas_x_preferred":[
+        "\u0628\u062e\u0634 \u0645\u0646\u0646\u06af"
+    ],
     "name:fin_x_preferred":[
         "Meneng"
     ],
     "name:fra_x_preferred":[
+        "Meneng"
+    ],
+    "name:frr_x_preferred":[
         "Meneng"
     ],
     "name:glv_x_preferred":[
@@ -109,6 +121,9 @@
     ],
     "name:kor_x_preferred":[
         "\uba54\ub139 \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\uba54\ub139\uad6c"
     ],
     "name:lav_x_preferred":[
         "Menengas distrikts"
@@ -164,6 +179,9 @@
     "name:swe_x_preferred":[
         "Meneng"
     ],
+    "name:szl_x_preferred":[
+        "Meneng"
+    ],
     "name:tam_x_preferred":[
         "\u0bae\u0bc7\u0ba9\u0bc6\u0b99\u0bcd \u0bae\u0bbe\u0bb5\u0b9f\u0bcd\u0b9f\u0bae\u0bcd"
     ],
@@ -190,6 +208,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6e44\u6fd8\u5340"
+    ],
+    "name:zho_x_variant":[
+        "\u6885\u5ae9\u533a"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"NRU",
@@ -310,7 +331,7 @@
         "eng",
         "nau"
     ],
-    "wof:lastmodified":1636494972,
+    "wof:lastmodified":1690849753,
     "wof:name":"Meneng",
     "wof:parent_id":85632747,
     "wof:placetype":"region",

--- a/data/856/756/77/85675677.geojson
+++ b/data/856/756/77/85675677.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.000141,
     "geom:area_square_m":1739415.404329,
-    "geom:bbox":"166.916351759,-0.550667846144,166.932640312,-0.534380806429",
+    "geom:bbox":"166.916352,-0.550668,166.93264,-0.534381",
     "geom:latitude":-0.543719,
     "geom:longitude":166.924097,
     "gn:id":"",
@@ -42,11 +42,23 @@
     "name:ara_x_preferred":[
         "\u0636\u0627\u062d\u064a\u0629 \u064a\u0627\u0631\u064a\u0646"
     ],
+    "name:ary_x_preferred":[
+        "\u064a\u0627\u0631\u064a\u0646"
+    ],
+    "name:arz_x_preferred":[
+        "\u0636\u0627\u062d\u064a\u0629 \u064a\u0627\u0631\u064a\u0646"
+    ],
     "name:ast_x_preferred":[
+        "Yaren"
+    ],
+    "name:avk_x_preferred":[
         "Yaren"
     ],
     "name:aze_x_preferred":[
         "Yaren"
+    ],
+    "name:ban_x_preferred":[
+        "Distrik Yar\u00e9n"
     ],
     "name:bel_x_preferred":[
         "\u042f\u0440\u044d\u043d"
@@ -74,6 +86,9 @@
     ],
     "name:ces_x_preferred":[
         "Yaren"
+    ],
+    "name:chu_x_preferred":[
+        "\ua656\u0440\u0454\u043d\u044a"
     ],
     "name:cym_x_preferred":[
         "Yaren"
@@ -114,8 +129,14 @@
     "name:fra_x_preferred":[
         "Yaren"
     ],
+    "name:frr_x_preferred":[
+        "Yaren"
+    ],
     "name:gla_x_preferred":[
         "Yaren"
+    ],
+    "name:gle_x_preferred":[
+        "Ceantar Yaren"
     ],
     "name:glg_x_preferred":[
         "Yaren"
@@ -156,6 +177,9 @@
     "name:ind_x_preferred":[
         "Yaren"
     ],
+    "name:isl_x_preferred":[
+        "Jaren"
+    ],
     "name:ita_x_preferred":[
         "Yaren"
     ],
@@ -178,7 +202,8 @@
         "\uc57c\ub80c"
     ],
     "name:kor_x_variant":[
-        "\uc57c\ub80c \uad6c"
+        "\uc57c\ub80c \uad6c",
+        "\uc57c\ub80c\uad6c"
     ],
     "name:lat_x_preferred":[
         "Yarenum"
@@ -188,6 +213,9 @@
     ],
     "name:lav_x_preferred":[
         "Jarena"
+    ],
+    "name:lij_x_preferred":[
+        "Yaren"
     ],
     "name:lit_x_preferred":[
         "Jarenas"
@@ -228,8 +256,14 @@
     "name:oci_x_preferred":[
         "Yaren"
     ],
+    "name:oss_x_preferred":[
+        "\u042f\u0440\u0435\u043d"
+    ],
     "name:pan_x_preferred":[
         "\u0a2f\u0a3e\u0a30\u0a28 \u0a1c\u0a3c\u0a3f\u0a32\u0a4d\u0a39\u0a3e"
+    ],
+    "name:pih_x_preferred":[
+        "Yaren"
     ],
     "name:pol_x_preferred":[
         "Yaren"
@@ -251,6 +285,9 @@
     ],
     "name:sco_x_preferred":[
         "Yaren"
+    ],
+    "name:sgs_x_preferred":[
+        "Jarens"
     ],
     "name:sin_x_preferred":[
         "\u0dba\u0dbb\u0dd9\u0db1\u0dca \u0daf\u0dd2\u0dc3\u0dca\u0dad\u0dca\u200d\u0dbb\u0dd2\u0d9a\u0dca\u0d9a\u0dba"
@@ -282,6 +319,9 @@
     "name:swe_x_preferred":[
         "Yaren"
     ],
+    "name:szl_x_preferred":[
+        "Yaren"
+    ],
     "name:tah_x_preferred":[
         "Yaren"
     ],
@@ -290,6 +330,9 @@
     ],
     "name:tel_x_preferred":[
         "\u0c2f\u0c46\u0c30\u0c46\u0c28\u0c4d \u0c1c\u0c3f\u0c32\u0c4d\u0c32\u0c3e"
+    ],
+    "name:tgk_x_preferred":[
+        "\u042f\u0440\u0435\u043d"
     ],
     "name:tgl_x_preferred":[
         "Yaren"
@@ -309,11 +352,20 @@
     "name:urd_x_preferred":[
         "\u06cc\u0627\u0631\u0646"
     ],
+    "name:uzb_x_preferred":[
+        "Yaren"
+    ],
     "name:vie_x_preferred":[
         "Yaren"
     ],
     "name:war_x_preferred":[
         "Yaren"
+    ],
+    "name:wuu_x_preferred":[
+        "\u4e9a\u4f26\u533a"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10d8\u10d0\u10e0\u10d4\u10dc\u10d8"
     ],
     "name:yue_x_preferred":[
         "\u4e9e\u502b"
@@ -430,7 +482,7 @@
         1108952597
     ],
     "wof:country":"NR",
-    "wof:geomhash":"de8fdf1aa2648ecea1a3772ca72e5a88",
+    "wof:geomhash":"26ed95fbdd888adf0f0a2ebff4e1b91e",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -447,7 +499,7 @@
         "eng",
         "nau"
     ],
-    "wof:lastmodified":1566672066,
+    "wof:lastmodified":1690849756,
     "wof:name":"Yaren",
     "wof:parent_id":85632747,
     "wof:placetype":"region",
@@ -462,10 +514,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    166.9163517587267,
-    -0.55066784614411,
-    166.9326403120009,
-    -0.534380806429
+    166.916352,
+    -0.550668,
+    166.93264,
+    -0.534381
 ],
-  "geometry": {"coordinates":[[[166.9326403120009,-0.55066784614411],[166.91635175872671,-0.54753997169229],[166.91826953601037,-0.54035014644205],[166.92009402481949,-0.53879933122408],[166.9252922897075,-0.534380806429],[166.9326403120009,-0.55066784614411]]],"type":"Polygon"}
+  "geometry": {"coordinates":[[[166.93263999999999,-0.550668],[166.91635199999999,-0.54754],[166.91827000000001,-0.54035],[166.92009400000001,-0.538799],[166.92529200000001,-0.534381],[166.93263999999999,-0.550668]]],"type":"Polygon"}
 }

--- a/data/890/436/403/890436403.geojson
+++ b/data/890/436/403/890436403.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:bel_x_preferred":[
+        "\u0410\u0440\u044b\u0436\u044d\u0436\u044d\u043d"
+    ],
     "name:eng_x_preferred":[
         "Arijejen"
     ],
@@ -27,6 +30,9 @@
     ],
     "name:pol_x_preferred":[
         "Arijejen"
+    ],
+    "name:rus_x_preferred":[
+        "\u0410\u0440\u0438\u0436\u0435\u0436\u0435\u043d"
     ],
     "qs:name":"Arijejen",
     "qs:photos_9r":0,
@@ -57,7 +63,7 @@
         }
     ],
     "wof:id":890436403,
-    "wof:lastmodified":1566672067,
+    "wof:lastmodified":1690849757,
     "wof:name":"Arijejen",
     "wof:parent_id":85675629,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.