### PR TITLE
nr concordances, placetype local, and more

### DIFF
--- a/data/856/327/47/85632747.geojson
+++ b/data/856/327/47/85632747.geojson
@@ -1037,6 +1037,7 @@
         "hasc:id":"NR",
         "icao:code":"C2",
         "ioc:id":"NRU",
+        "iso:code":"NR",
         "itu:id":"NRU",
         "loc:id":"n82076382",
         "m49:code":"520",
@@ -1051,6 +1052,7 @@
         "wk:page":"Nauru",
         "wmo:id":"NW"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NR",
     "wof:country_alpha3":"NRU",
     "wof:geom_alt":[
@@ -1074,7 +1076,7 @@
         "eng",
         "nau"
     ],
-    "wof:lastmodified":1694639667,
+    "wof:lastmodified":1695881327,
     "wof:name":"Nauru",
     "wof:parent_id":102191583,
     "wof:placetype":"country",

--- a/data/856/756/07/85675607.geojson
+++ b/data/856/756/07/85675607.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000215,
-    "geom:area_square_m":2652267.127724,
+    "geom:area_square_m":2652292.704063,
     "geom:bbox":"166.916163,-0.538799,166.936135,-0.520686",
     "geom:latitude":-0.528541,
     "geom:longitude":166.924723,
@@ -304,14 +304,16 @@
         "gn:id":2110440,
         "gp:id":20070303,
         "hasc:id":"NR.BU",
+        "iso:code":"NR-07",
         "iso:id":"NR-07",
         "qs_pg:id":49493,
         "unlc:id":"NR-07",
         "wd:id":"Q202747",
         "wk:page":"Buada District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NR",
-    "wof:geomhash":"a4f4e023b964ef0470e6078436096048",
+    "wof:geomhash":"927a9ef91ab9177855ec7dbde032e2d4",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -328,7 +330,7 @@
         "eng",
         "nau"
     ],
-    "wof:lastmodified":1690849754,
+    "wof:lastmodified":1695884783,
     "wof:name":"Buada",
     "wof:parent_id":85632747,
     "wof:placetype":"region",

--- a/data/856/756/25/85675625.geojson
+++ b/data/856/756/25/85675625.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000047,
-    "geom:area_square_m":578927.815023,
+    "geom:area_square_m":578952.652865,
     "geom:bbox":"166.911993,-0.54754,166.920094,-0.535083",
     "geom:latitude":-0.539821,
     "geom:longitude":166.916065,
@@ -308,14 +308,16 @@
         "gn:id":2110441,
         "gp:id":20070299,
         "hasc:id":"NR.BO",
+        "iso:code":"NR-06",
         "iso:id":"NR-06",
         "qs_pg:id":49490,
         "unlc:id":"NR-06",
         "wd:id":"Q378829",
         "wk:page":"Boe District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NR",
-    "wof:geomhash":"855e4bebc2b9690e2c81e018bbee54d9",
+    "wof:geomhash":"12c1cc1437cf9f3d5f99c7f12f4b98c7",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -332,7 +334,7 @@
         "eng",
         "nau"
     ],
-    "wof:lastmodified":1690849756,
+    "wof:lastmodified":1695884783,
     "wof:name":"Boe",
     "wof:parent_id":85632747,
     "wof:placetype":"region",

--- a/data/856/756/29/85675629.geojson
+++ b/data/856/756/29/85675629.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000088,
-    "geom:area_square_m":1091773.636025,
+    "geom:area_square_m":1091737.693173,
     "geom:bbox":"166.906993,-0.536965,166.917918,-0.524198",
     "geom:latitude":-0.529894,
     "geom:longitude":166.912956,
@@ -317,14 +317,16 @@
         "gn:id":2110451,
         "gp:id":20070298,
         "hasc:id":"NR.AI",
+        "iso:code":"NR-01",
         "iso:id":"NR-01",
         "qs_pg:id":49489,
         "unlc:id":"NR-01",
         "wd:id":"Q240017",
         "wk:page":"Aiwo District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NR",
-    "wof:geomhash":"57434a2d1a5d864c856eb4110a314d22",
+    "wof:geomhash":"307b68cefbb55a3540c0807bceaa04a9",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -341,7 +343,7 @@
         "eng",
         "nau"
     ],
-    "wof:lastmodified":1690849754,
+    "wof:lastmodified":1695884783,
     "wof:name":"Aiwo",
     "wof:parent_id":85632747,
     "wof:placetype":"region",

--- a/data/856/756/33/85675633.geojson
+++ b/data/856/756/33/85675633.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000095,
-    "geom:area_square_m":1168487.311472,
+    "geom:area_square_m":1168477.090612,
     "geom:bbox":"166.906993,-0.524835,166.920376,-0.512107",
     "geom:latitude":-0.519901,
     "geom:longitude":166.912935,
@@ -323,14 +323,16 @@
         "gn:id":2110437,
         "gp:id":20070302,
         "hasc:id":"NR.DE",
+        "iso:code":"NR-08",
         "iso:id":"NR-08",
         "qs_pg:id":49492,
         "unlc:id":"NR-08",
         "wd:id":"Q1187200",
         "wk:page":"Denigomodu District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NR",
-    "wof:geomhash":"f23f17ede9c0fd8a35806e7ad4c37a24",
+    "wof:geomhash":"a9485d51ed546931f41a342bfec2f3bc",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -347,7 +349,7 @@
         "eng",
         "nau"
     ],
-    "wof:lastmodified":1690849753,
+    "wof:lastmodified":1695884783,
     "wof:name":"Denigomodu",
     "wof:parent_id":85632747,
     "wof:placetype":"region",

--- a/data/856/756/37/85675637.geojson
+++ b/data/856/756/37/85675637.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000283,
-    "geom:area_square_m":3496744.289341,
+    "geom:area_square_m":3496609.924095,
     "geom:bbox":"166.910312,-0.525195,166.936798,-0.500177",
     "geom:latitude":-0.514142,
     "geom:longitude":166.922311,
@@ -302,14 +302,16 @@
         "gn:id":2110423,
         "gp:id":20070306,
         "hasc:id":"NR.NI",
+        "iso:code":"NR-12",
         "iso:id":"NR-12",
         "qs_pg:id":49495,
         "unlc:id":"NR-12",
         "wd:id":"Q378780",
         "wk:page":"Nibok District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NR",
-    "wof:geomhash":"90bdb89e49b438d61f7ae13c89d336e0",
+    "wof:geomhash":"89015b4ab7cde3886bd3456bb082782d",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -326,7 +328,7 @@
         "eng",
         "nau"
     ],
-    "wof:lastmodified":1690849755,
+    "wof:lastmodified":1695884783,
     "wof:name":"Nibok",
     "wof:parent_id":85632747,
     "wof:placetype":"region",

--- a/data/856/756/41/85675641.geojson
+++ b/data/856/756/41/85675641.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000107,
-    "geom:area_square_m":1319294.730301,
+    "geom:area_square_m":1319319.965588,
     "geom:bbox":"166.913422,-0.520199,166.93724,-0.49839",
     "geom:latitude":-0.508262,
     "geom:longitude":166.925688,
@@ -297,14 +297,16 @@
         "gn:id":2110420,
         "gp:id":20070307,
         "hasc:id":"NR.UA",
+        "iso:code":"NR-13",
         "iso:id":"NR-13",
         "qs_pg:id":66072,
         "unlc:id":"NR-13",
         "wd:id":"Q473764",
         "wk:page":"Uaboe District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NR",
-    "wof:geomhash":"66e8366bcd196289f51fec6631e3f1ff",
+    "wof:geomhash":"d6f97d8f33e56ba330f00592f67e4403",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -321,7 +323,7 @@
         "eng",
         "nau"
     ],
-    "wof:lastmodified":1690849755,
+    "wof:lastmodified":1695884783,
     "wof:name":"Uaboe",
     "wof:parent_id":85632747,
     "wof:placetype":"region",

--- a/data/856/756/45/85675645.geojson
+++ b/data/856/756/45/85675645.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000135,
-    "geom:area_square_m":1664395.010328,
+    "geom:area_square_m":1664459.812065,
     "geom:bbox":"166.918067,-0.516516,166.938048,-0.495675",
     "geom:latitude":-0.504861,
     "geom:longitude":166.929014,
@@ -298,14 +298,16 @@
         "gn:id":2110442,
         "gp:id":20070309,
         "hasc:id":"NR.BA",
+        "iso:code":"NR-05",
         "iso:id":"NR-05",
         "qs_pg:id":49496,
         "unlc:id":"NR-05",
         "wd:id":"Q328727",
         "wk:page":"Baitsi District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NR",
-    "wof:geomhash":"5dca82b58daaa19502c55b61dad14022",
+    "wof:geomhash":"c17aa226fb5549343fd0b6c23fbe8ec7",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -322,7 +324,7 @@
         "eng",
         "nau"
     ],
-    "wof:lastmodified":1690849754,
+    "wof:lastmodified":1695884783,
     "wof:name":"Baiti",
     "wof:parent_id":85632747,
     "wof:placetype":"region",

--- a/data/856/756/49/85675649.geojson
+++ b/data/856/756/49/85675649.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00009,
-    "geom:area_square_m":1111828.13098,
+    "geom:area_square_m":1111858.408789,
     "geom:bbox":"166.925126,-0.51052,166.938987,-0.49334",
     "geom:latitude":-0.500784,
     "geom:longitude":166.932987,
@@ -298,14 +298,16 @@
         "gn:id":2110435,
         "gp:id":20070310,
         "hasc:id":"NR.EW",
+        "iso:code":"NR-09",
         "iso:id":"NR-09",
         "qs_pg:id":49497,
         "unlc:id":"NR-09",
         "wd:id":"Q274381",
         "wk:page":"Ewa District, Nauru"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NR",
-    "wof:geomhash":"0606842d32b9c24c34e6b7a0a7ed300b",
+    "wof:geomhash":"c618b960a0617716cc105ca81ae8ea5b",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -322,7 +324,7 @@
         "eng",
         "nau"
     ],
-    "wof:lastmodified":1690849756,
+    "wof:lastmodified":1695884783,
     "wof:name":"Ewa",
     "wof:parent_id":85632747,
     "wof:placetype":"region",

--- a/data/856/756/55/85675655.geojson
+++ b/data/856/756/55/85675655.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000053,
-    "geom:area_square_m":651577.742382,
+    "geom:area_square_m":651603.998697,
     "geom:bbox":"166.931197,-0.504183,166.938987,-0.490411",
     "geom:latitude":-0.495978,
     "geom:longitude":166.936332,
@@ -298,14 +298,16 @@
         "gn:id":2110448,
         "gp:id":20070311,
         "hasc:id":"NR.AT",
+        "iso:code":"NR-03",
         "iso:id":"NR-03",
         "qs_pg:id":240461,
         "unlc:id":"NR-03",
         "wd:id":"Q378813",
         "wk:page":"Anetan District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NR",
-    "wof:geomhash":"d3ac33e796fc8980c1b9e5ecc4e72486",
+    "wof:geomhash":"9a95c8263f533fe8407c21c6452b27e6",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -322,7 +324,7 @@
         "eng",
         "nau"
     ],
-    "wof:lastmodified":1690849755,
+    "wof:lastmodified":1695884783,
     "wof:name":"Anetan",
     "wof:parent_id":85632747,
     "wof:placetype":"region",

--- a/data/856/756/59/85675659.geojson
+++ b/data/856/756/59/85675659.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000115,
-    "geom:area_square_m":1419223.860271,
+    "geom:area_square_m":1419205.114868,
     "geom:bbox":"166.938813,-0.504183,166.955577,-0.490411",
     "geom:latitude":-0.497524,
     "geom:longitude":166.944459,
@@ -301,14 +301,16 @@
         "gn:id":2110449,
         "gp:id":20070308,
         "hasc:id":"NR.AB",
+        "iso:code":"NR-02",
         "iso:id":"NR-02",
         "qs_pg:id":1149776,
         "unlc:id":"NR-02",
         "wd:id":"Q328735",
         "wk:page":"Anabar District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NR",
-    "wof:geomhash":"98a61a1a6470923aac967daee0afaaf0",
+    "wof:geomhash":"af6276fd3e3c38f4c2163489732dd3d4",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -325,7 +327,7 @@
         "eng",
         "nau"
     ],
-    "wof:lastmodified":1690849753,
+    "wof:lastmodified":1695884783,
     "wof:name":"Anabar",
     "wof:parent_id":85632747,
     "wof:placetype":"region",

--- a/data/856/756/63/85675663.geojson
+++ b/data/856/756/63/85675663.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000131,
-    "geom:area_square_m":1617317.640812,
+    "geom:area_square_m":1617345.724834,
     "geom:bbox":"166.938987,-0.511329,166.957397,-0.497979",
     "geom:latitude":-0.504893,
     "geom:longitude":166.950328,
@@ -295,14 +295,16 @@
         "gn:id":2110432,
         "gp:id":20070305,
         "hasc:id":"NR.IJ",
+        "iso:code":"NR-10",
         "iso:id":"NR-10",
         "qs_pg:id":49494,
         "unlc:id":"NR-10",
         "wd:id":"Q328738",
         "wk:page":"Ijuw District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NR",
-    "wof:geomhash":"fed7986af2ce7f6b2a517a7abe7e6603",
+    "wof:geomhash":"35452ca79215d7376e5e691593c978f1",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -319,7 +321,7 @@
         "eng",
         "nau"
     ],
-    "wof:lastmodified":1690849755,
+    "wof:lastmodified":1695884783,
     "wof:name":"Ijuw",
     "wof:parent_id":85632747,
     "wof:placetype":"region",

--- a/data/856/756/67/85675667.geojson
+++ b/data/856/756/67/85675667.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000465,
-    "geom:area_square_m":5746860.666489,
+    "geom:area_square_m":5746899.682263,
     "geom:bbox":"166.935475,-0.533383,166.958263,-0.504183",
     "geom:latitude":-0.520002,
     "geom:longitude":166.946512,
@@ -298,14 +298,16 @@
         "gn:id":2110445,
         "gp:id":20070304,
         "hasc:id":"NR.AR",
+        "iso:code":"NR-04",
         "iso:id":"NR-04",
         "qs_pg:id":1149777,
         "unlc:id":"NR-04",
         "wd:id":"Q328733",
         "wk:page":"Anibare District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NR",
-    "wof:geomhash":"f1ec4e30571d117c3d620901b395f955",
+    "wof:geomhash":"7917fa946c5da8420a0b31563273290b",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -322,7 +324,7 @@
         "eng",
         "nau"
     ],
-    "wof:lastmodified":1690849753,
+    "wof:lastmodified":1695884783,
     "wof:name":"Anibare",
     "wof:parent_id":85632747,
     "wof:placetype":"region",

--- a/data/856/756/69/85675669.geojson
+++ b/data/856/756/69/85675669.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000375,
-    "geom:area_square_m":4639942.640082,
+    "geom:area_square_m":4640033.790563,
     "geom:bbox":"166.925292,-0.551853,166.953205,-0.529816",
     "geom:latitude":-0.539624,
     "geom:longitude":166.938592,
@@ -307,14 +307,16 @@
         "gn:id":2110431,
         "gp:id":20070301,
         "hasc:id":"NR.ME",
+        "iso:code":"NR-11",
         "iso:id":"NR-11",
         "qs_pg:id":49491,
         "unlc:id":"NR-11",
         "wd:id":"Q327788",
         "wk:page":"Meneng District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NR",
-    "wof:geomhash":"d5d5a526d1366c905ddc6163ac0cd3b4",
+    "wof:geomhash":"39d1ec4e1593a408cbd85b3e15c0c7c4",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -331,7 +333,7 @@
         "eng",
         "nau"
     ],
-    "wof:lastmodified":1690849753,
+    "wof:lastmodified":1695884783,
     "wof:name":"Meneng",
     "wof:parent_id":85632747,
     "wof:placetype":"region",

--- a/data/856/756/77/85675677.geojson
+++ b/data/856/756/77/85675677.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000141,
-    "geom:area_square_m":1739415.404329,
+    "geom:area_square_m":1739342.988859,
     "geom:bbox":"166.916352,-0.550668,166.93264,-0.534381",
     "geom:latitude":-0.543719,
     "geom:longitude":166.924097,
@@ -472,17 +472,19 @@
         "gn:id":2110418,
         "gp:id":20070300,
         "hasc:id":"NR.YA",
+        "iso:code":"NR-14",
         "iso:id":"NR-14",
         "qs_pg:id":1014924,
         "unlc:id":"NR-14",
         "wd:id":"Q31026",
         "wk:page":"Yaren District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         1108952597
     ],
     "wof:country":"NR",
-    "wof:geomhash":"26ed95fbdd888adf0f0a2ebff4e1b91e",
+    "wof:geomhash":"6bbef6f271067688773f5d1b9eb1f471",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -499,7 +501,7 @@
         "eng",
         "nau"
     ],
-    "wof:lastmodified":1690849756,
+    "wof:lastmodified":1695884329,
     "wof:name":"Yaren",
     "wof:parent_id":85632747,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.